### PR TITLE
Issue #6: XDG Basedirs support for `{,un}install.sh`

### DIFF
--- a/git-semver.sh
+++ b/git-semver.sh
@@ -410,35 +410,23 @@ version-do() {
 # Set home
 readonly DIR_HOME="${HOME}"
 
-# Check XDG Base Directories
+# Use XDG Base Directories if possible
 # (see http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
-XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+DIR_CONF="${XDG_CONFIG_HOME:-$HOME}/.git-semver"
+DIR_DATA="${XDG_DATA_HOME:-$HOME}/.git-semver"
 
 # Set default config
 UPDATE_CHECK=1
 UPDATE_CHECK_INTERVAL_DAYS=1
 
 # Set (and load) user config
-if [ -f "${XDG_CONFIG_HOME}/.git-semver/config" ]
+if [ -f "${DIR_CONF}/config" ]
 then
-    FILE_CONF="${XDG_CONFIG_HOME}/.git-semver/config"
-    source "${FILE_CONF}"
-elif [ -f "${DIR_HOME}/.git-semver/config" ]
-then
-    FILE_CONF="${DIR_HOME}/.git-semver/config"
+    FILE_CONF="${DIR_CONF}/config"
     source "${FILE_CONF}"
 else
     # No existing config file was found; use default
     FILE_CONF="${DIR_HOME}/.git-semver/config"
-fi
-
-# Set Data Dir
-if [ -d "${XDG_DATA_HOME}/.git-semver" ]
-then
-    DIR_DATA="${XDG_DATA_HOME}/.git-semver"
-else
-    DIR_DATA="${DIR_HOME}/.git-semver"
 fi
 
 # Set vars

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@ pushd $(dirname $0) > /dev/null
 DIR_SELF=$(pwd -P)
 popd > /dev/null
 
-DIR_DATA="${HOME}/.git-semver"
+readonly DIR_HOME="${HOME}"
 
 # Running on MinGW
 uname -s | grep -q 'MINGW[^_]\+_NT'
@@ -21,10 +21,15 @@ do
     fi
 done
 
+# Use XDG Base Directories if available
+# (see http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+DIR_CONF_DEST="${XDG_CONFIG_HOME:-$DIR_HOME}/.git-semver"
+DIR_DATA="${XDG_DATA_HOME:-$DIR_HOME}/.git-semver"
+
 FILE_SRC="${DIR_SELF}/git-semver.sh"
 FILE_DEST="${DIR_BIN}/git-semver"
 FILE_CONF_SRC="${DIR_SELF}/config.example"
-FILE_CONF_DEST="${DIR_DATA}/config"
+FILE_CONF_DEST="${DIR_CONF_DEST}/config"
 
 # If MinGW
 if [ ${OS_MINGW} -eq 0 ]
@@ -56,8 +61,11 @@ else
     ln -s "${FILE_SRC}" "${FILE_DEST}"
 fi
 
-# Copy configuration
+# Make data dir
 mkdir -p "${DIR_DATA}"
+
+# Copy configuration
+mkdir -p "${DIR_CONF_DEST}"
 if [ ! -f "${FILE_CONF_DEST}" ]
 then
     cp "${FILE_CONF_SRC}" "${FILE_CONF_DEST}"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,5 +11,8 @@ done
 
 if [ "$1" == "-p" ] || [ "$1" == "--purge" ]
 then
-    rm -rf ${HOME}/.git-semver
+    DIR_CONF_DEST="${XDG_CONFIG_HOME:-$DIR_HOME}/.git-semver"
+    DIR_DATA="${XDG_DATA_HOME:-$DIR_HOME}/.git-semver"
+    
+    rm -rf "${DIR_CONF_DEST}" "${DIR_DATA}"
 fi


### PR DESCRIPTION
I forgot to update the `{,un}install.sh` scripts in my last PR.  Sorry about that!

Here’s the fix.  

(Also, tidied up some variables-setup at the end of the main script.)
