### PR TITLE
Fix printf for OSX

### DIFF
--- a/git-semver.sh
+++ b/git-semver.sh
@@ -283,7 +283,15 @@ plugin-list() {
         plugin_dir="${dirs[${i}]}/.git-semver/plugins"
         if [ -d "${plugin_dir}" ]
         then
-            find "${plugin_dir}" -maxdepth 1 -type f \( -perm -u=x -o -perm -g=x -o -perm -o=x \) -exec bash -c "[ -x {} ]" \; -printf "${plugin_type},%p \n"
+            case "$OSTYPE" in
+                darwin*|bsd*)
+                    plugin=$(find "${plugin_dir}" -maxdepth 1 -type f \( -perm -u=x -o -perm -g=x -o -perm -o=x \) -exec bash -c "[ -x {} ]" \; -print | xargs echo "${plugin_type},")
+                    echo ${plugin/' '/}
+                ;;
+                *)
+                    find "${plugin_dir}" -maxdepth 1 -type f \( -perm -u=x -o -perm -g=x -o -perm -o=x \) -exec bash -c "[ -x {} ]" \; -printf "${plugin_type},%p \n"
+                ;;
+            esac
         fi
     done
 }


### PR DESCRIPTION
`-printf` does not exists for BSD find command so I was getting the following error when the folder **.git-semver/plugins** exists:  

```
git semver next
find: -printf: unknown primary or operator
```

This PR fix this for OSX using `-print` and `xargs`removing the remaining space.
