### PR TITLE
Add DRYRUN flag to semver commands to allow checking tags without creating them

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ Will return empty if no version has been created.
 Versions are created as tags and are generated using:
 
 ``` bash
-git semver [major|minor|patch|next|pre-release|build] [-p <pre-release>] [-b <build>]
+git semver [major|minor|patch|next|pre-release|build] [--dryrun] [-p <pre-release>] [-b <build>]
+```
+
+To see what a tag would be without actually creating it, run a dryrun with `-d` or `--dryrun`:
+
+```
+git semver patch --dryrun
 ```
 
 #### Major

--- a/git-semver.sh
+++ b/git-semver.sh
@@ -12,13 +12,13 @@ usage() {
 		See https://github.com/markchalloner/git-semver for more detail.
 
 		Commands
-		 get                                        Gets the current version (tag)
-		 major [-p <pre-release>] [-b <build>]      Generates a tag for the next major version and echos to the screen
-		 minor [-p [<pre-release> [-b <build>]      Generates a tag for the next minor version and echos to the screen
-		 patch|next [-p <pre-release>] [-b <build>] Generates a tag for the next patch version and echos to the screen
-		 pre-release -p <pre-release> [-b <build>]  Generates a tag for a pre-release version and echos to the screen
-		 build -b <build>                           Generates a tag for a build and echos to the screen
-		 help       This message
+		 get                                                   Gets the current version (tag)
+		 major [--dryrun] [-p <pre-release>] [-b <build>]      Generates a tag for the next major version and echos to the screen
+		 minor [--dryrun] [-p [<pre-release> [-b <build>]      Generates a tag for the next minor version and echos to the screen
+		 patch|next [--dryrun] [-p <pre-release>] [-b <build>] Generates a tag for the next patch version and echos to the screen
+		 pre-release [--dryrun] -p <pre-release> [-b <build>]  Generates a tag for a pre-release version and echos to the screen
+		 build [--dryrun] -b <build>                           Generates a tag for a build and echos to the screen
+		 help                                                  This message
 
 	EOF
 	exit
@@ -323,7 +323,10 @@ version-do() {
     then
         cmd="$cmd -as -m $new"
     fi
-    if plugin-run "$new" "$version"
+    if [ $dryrun == 1 ]
+    then
+        echo "$new"
+    elif plugin-run "$new" "$version"
     then
         $cmd "$new" && echo "$new"
     fi
@@ -365,9 +368,16 @@ GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2> /dev/null)"
 action=
 build=
 pre_release=
+dryrun=0
 while :
 do
     case "$1" in
+        -d)
+            dryrun=1
+            ;;
+        --dryrun)
+            dryrun=1
+            ;;
         -b)
             build=$2
             shift


### PR DESCRIPTION
This is useful to be able to update files and create a custom release commit that includes the version before tagging it.

Example: https://github.com/justinbarrick/fluxcloud/blob/master/Makefile#L9-L10