### PR TITLE
Fix stripping VERSION_PREFIX from major versions to prevent creating versions with double versions.

### DIFF
--- a/git-semver.sh
+++ b/git-semver.sh
@@ -154,7 +154,7 @@ validate-build() {
 ########################################
 
 version-parse-major() {
-    echo "$1" | cut -d "." -f1 | sed 's/^${VERSION_PREFIX}//g'
+    echo "$1" | cut -d "." -f1 | sed "s/^${VERSION_PREFIX}//g"
 }
 
 version-parse-minor() {


### PR DESCRIPTION
I had a `VERSION_PREFIX=v` which caused my versions to have two "v":

```
➜  fluxcloud git:(master) ✗ git semver --dryrun patch
vv0.2.11
➜  fluxcloud git:(master) ✗
```

Bash does not interpolate variables inside of single quotes, so this fixes the sed
command in version-parse-major to use double quotes so that the VERSION_PREFIX
gets properly stripped.